### PR TITLE
Summary of updates

### DIFF
--- a/src/RpcFieldError.php
+++ b/src/RpcFieldError.php
@@ -2,10 +2,13 @@
 
 namespace Terah\JsonRpc;
 
-class RpcFieldError
+class RpcFieldError implements \JsonSerializable
 {
     /** @var string */
     protected $name     = '';
+
+    /** @var string[] */
+    protected $messages = [];
 
     /**
      * @return string
@@ -32,6 +35,14 @@ class RpcFieldError
     }
 
     /**
+     * @param string $message
+     */
+    public function setMessage(string $message) : void
+    {
+        $this->messages[] = $message;
+    }
+
+    /**
      * @param string[] $messages
      */
     public function setMessages(array $messages) : void
@@ -39,8 +50,23 @@ class RpcFieldError
         $this->messages = $messages;
     }
 
-    /** @var string[] */
-    protected $messages = [];
+    /**
+     * @return object
+     */
+    public function jsonSerialize()
+    {
+        return (object)$this->toArray();
+    }
 
+    /**
+     * @return array
+     */
+    public function toArray() : array
+    {
+        return [
+            'name'          => $this->getName(),
+            'messages'      => $this->getMessages()
+        ];
+    }
 
 }

--- a/src/RpcFieldErrorCollection.php
+++ b/src/RpcFieldErrorCollection.php
@@ -2,7 +2,7 @@
 
 namespace Terah\JsonRpc;
 
-class RpcFieldErrorCollection
+class RpcFieldErrorCollection implements \JsonSerializable
 {
     /** @var RpcFieldError[] */
     protected $fieldErrors = [];
@@ -36,12 +36,6 @@ class RpcFieldErrorCollection
      */
     public function jsonSerialize()
     {
-        $data = [];
-        foreach ( $this->fieldErrors as $fieldError )
-        {
-            $data[$fieldError->getName()] = $fieldError->getMessages();
-        }
-
-        return (object)$data;
+        return (object)$this->getFieldErrors();
     }
 }

--- a/src/RpcResponse.php
+++ b/src/RpcResponse.php
@@ -34,12 +34,16 @@ class RpcResponse implements \JsonSerializable
         {
             return ;
         }
-        Assert($data)->code(-32700)->isObject('Parse error: Invalid JSON was received by the server.');
-        Assert($data)->code(-32600)->propertiesExist(['jsonrpc'], 'Invalid Request: The JSON sent is not a valid Request object.');
+        Assert($data)
+            ->code(-32700)
+            ->isObject('Parse error: Invalid JSON was received by the server.');
 
-        $this
-            ->setJsonrpc($data->jsonrpc)
-            ->setId($data->id ?? null);
+        Assert($data)
+            ->code(-32600)
+            ->propertiesExist(['jsonrpc'], 'Invalid Request: The JSON sent is not a valid Request object.');
+
+        $this->setJsonrpc($data->jsonrpc)->setId($data->id ?? null);
+
         if ( isset($data->error) )
         {
             $rpcError = new RpcError;
@@ -58,7 +62,8 @@ class RpcResponse implements \JsonSerializable
      */
     public function getJsonrpc() : string
     {
-        Assert($this->jsonrpc)->eq('2.0', 'The jsonrpc version must be 2.0');
+        Assert($this->jsonrpc)
+            ->eq('2.0', 'The jsonrpc version must be 2.0');
 
         return $this->jsonrpc;
     }
@@ -69,7 +74,8 @@ class RpcResponse implements \JsonSerializable
      */
     public function setJsonrpc(string $jsonrpc) : RpcResponse
     {
-        Assert($jsonrpc)->eq('2.0', 'The jsonrpc version must be 2.0');
+        Assert($jsonrpc)
+            ->eq('2.0', 'The jsonrpc version must be 2.0');
 
         $this->jsonrpc = $jsonrpc;
 
@@ -150,14 +156,12 @@ class RpcResponse implements \JsonSerializable
      */
     public function jsonSerialize()
     {
-        $result         =  new \stdClass();
-        $result->jsonrpc  = $this->getJsonrpc();
-        $result->result = $this->getResult();
+        $result             =  new \stdClass();
+        $result->jsonrpc    = $this->getJsonrpc();
+        $result->result     = $this->getResult();
         if ( $this->error )
         {
             $result->error  = $this->getError();
-
-            return $result;
         }
         if ( $this->id )
         {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description


- RpcResponse: Updated public function jsonSerialize()  
           - Removed early return of $result, which caused rpc id to be missed when a returning response object that contained errors.

Updated RpcFieldError and RpcFieldErrorCollection:
- now serializable
- added setMessage() to RpcFieldError to allow addition of individual messages to the messages array
- simplified RpcFieldErrorCollection jsonSerialize


